### PR TITLE
feat(dictonary): a few more misspellings

### DIFF
--- a/lua/thethethe/dictionary.lua
+++ b/lua/thethethe/dictionary.lua
@@ -12436,4 +12436,11 @@ YEras:Years
 yersa:years
 Yersa:Years
 YErsa:Years
+defualt:default
+Defualt:Default
+DEfualt:Default
+locatoin:location
+Locatoin:Location
+LOcatoin:Location
+NOne:None
 ]]


### PR DESCRIPTION
This plugin is a great idea! I have also been using my config to manage common typos. In this PR I added a few which I rely on:

* NOne -> None (+ variants; common in Rust code)
* defualt -> default (+ variants; common in C# code)
* Locatoin -> Location (+ variants)

At first, I went to alphabetize these additions, but I noticed that the dictionary itself is not alphabetized so I simply appended them. Let me know if there is some other place you would like them to go.

Btw, what was the motivation for using a string instead of a table for the dictionary (e.g. `[[FOo:Foo]]` over `{FOo = 'Foo'}`)?